### PR TITLE
SWI-2827 Add Repo to Service Catalog

### DIFF
--- a/.bandwidth/catalog-info.yaml
+++ b/.bandwidth/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  schemaVersion: v1.0.0
+  name: action-tmate-fork-location
+  description: Links to additional entities in the action-tmate-fork repository.
+  annotations:
+    github.com/project-slug: Bandwidth/action-tmate-fork
+spec:
+  targets:
+    - ./component.yaml

--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  schemaVersion: v1.0.0
+  name: action-tmate-fork
+  description: Bandwidth fork of mxschmitt/action-tmate. A GitHub Action for
+    interactively debugging CI workflows via SSH or web shell using tmate
+    sessions.
+  annotations:
+    github.com/project-slug: Bandwidth/action-tmate-fork
+  organization: BW
+  costCenter: Development - Software Infra
+spec:
+  type: GitHub Action
+  owner: github/band-swi
+  lifecycle: Available


### PR DESCRIPTION
Auto-generated by the Backstage Service Catalog. Adds a `catalog-info.yaml` Location and `component.yaml` Component to represent this repository.